### PR TITLE
remove dots from cookies

### DIFF
--- a/server-cookies.js
+++ b/server-cookies.js
@@ -29,7 +29,11 @@ var packageFunction = function() {
     WebApp.connectHandlers.use('/cookieToken', function(req, res, next) {
         Fiber(function() {
             var token = req.query.token,
-            reqCookies = parseCookies(req);
+            parsedCookies = parseCookies(req),
+            reqCookies = {};
+            for (var k in parsedCookies) {
+              reqCookies[k.replace(/\./g, '%2E')] = parsedCookies[k];
+            }
             cookieTokenDoc = cookieTokens.findOne({_id: token});
 
             if (cookieTokenDoc && cookieTokenDoc.cookies === null) {


### PR DESCRIPTION
to fix errors like:

```
MongoError: The dotted field '_somecookie_id.42' in '_somecookie_id.42' is not valid for storage.
```
